### PR TITLE
refactor: update data types to bytes in Block and Transaction messages

### DIFF
--- a/pb/entity/domain/block/model/model.proto
+++ b/pb/entity/domain/block/model/model.proto
@@ -3,8 +3,8 @@ syntax = "proto3";
 import "google/protobuf/timestamp.proto";
 
 message Block {
-    string id = 1;
+    bytes id = 1;
     int64 height = 2;
     google.protobuf.Timestamp timestamp = 3;
-    repeated string transaction_ids = 4;
+    repeated bytes transaction_ids = 4;
 }

--- a/pb/entity/domain/transaction/model/model.proto
+++ b/pb/entity/domain/transaction/model/model.proto
@@ -3,10 +3,10 @@ syntax = "proto3";
 import "google/protobuf/timestamp.proto";
 
 message Transaction {
-    string id = 1;
-    string block_id = 2;
-    string from = 3;
-    string to = 4;
+    bytes id = 1;
+    bytes block_id = 2;
+    bytes from = 3;
+    bytes to = 4;
     double amount = 5;
     google.protobuf.Timestamp timestamp = 6;
 }


### PR DESCRIPTION
- Change the type of `id`, `transaction_ids`, `block_id`, `from`, and `to` fields from `string` to `bytes` in the `Block` and `Transaction` messages.