### PR TITLE
feat: refactor block scanning service initialization

### DIFF
--- a/adapter/block/scan/impl.go
+++ b/adapter/block/scan/impl.go
@@ -8,11 +8,14 @@ import (
 )
 
 type impl struct {
+	injector *Injector
 }
 
 // NewServer is used to create a new scan server
-func NewServer() adapterx.Server {
-	return &impl{}
+func NewServer(injector *Injector) adapterx.Server {
+	return &impl{
+		injector: injector,
+	}
 }
 
 func (i *impl) Start(c context.Context) error {

--- a/adapter/block/scan/injector.go
+++ b/adapter/block/scan/injector.go
@@ -1,0 +1,11 @@
+package scan
+
+import (
+	"github.com/blackhorseya/ryze/app/infra/configx"
+)
+
+// Injector is used to inject the dependencies.
+type Injector struct {
+	C *configx.Configuration
+	A *configx.Application
+}

--- a/adapter/block/scan/wire.go
+++ b/adapter/block/scan/wire.go
@@ -5,13 +5,47 @@
 package scan
 
 import (
+	"fmt"
+
+	"github.com/blackhorseya/ryze/app/infra/configx"
+	"github.com/blackhorseya/ryze/app/infra/transports/grpcx"
 	"github.com/blackhorseya/ryze/pkg/adapterx"
 	"github.com/google/wire"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
 )
+
+const serviceName = "block-scanner"
+
+// NewInitServersFn creates a new grpc server initializer.
+func NewInitServersFn() grpcx.InitServers {
+	return func(s *grpc.Server) {
+		healthServer := health.NewServer()
+		grpc_health_v1.RegisterHealthServer(s, healthServer)
+		healthServer.SetServingStatus(serviceName, grpc_health_v1.HealthCheckResponse_SERVING)
+
+		reflection.Register(s)
+	}
+}
+
+// InitApplication is used to initialize the application.
+func InitApplication(config *configx.Configuration) (*configx.Application, error) {
+	app, err := config.GetService(serviceName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service %s: %w", serviceName, err)
+	}
+
+	return app, nil
+}
 
 func New(v *viper.Viper) (adapterx.Server, func(), error) {
 	panic(wire.Build(
 		NewServer,
+		wire.Struct(new(Injector), "*"),
+		configx.NewConfiguration,
+		InitApplication,
 	))
 }

--- a/adapter/block/scan/wire_gen.go
+++ b/adapter/block/scan/wire_gen.go
@@ -7,14 +7,57 @@
 package scan
 
 import (
+	"fmt"
+	"github.com/blackhorseya/ryze/app/infra/configx"
+	"github.com/blackhorseya/ryze/app/infra/transports/grpcx"
 	"github.com/blackhorseya/ryze/pkg/adapterx"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
 )
 
 // Injectors from wire.go:
 
 func New(v *viper.Viper) (adapterx.Server, func(), error) {
-	server := NewServer()
+	configuration, err := configx.NewConfiguration(v)
+	if err != nil {
+		return nil, nil, err
+	}
+	application, err := InitApplication(configuration)
+	if err != nil {
+		return nil, nil, err
+	}
+	injector := &Injector{
+		C: configuration,
+		A: application,
+	}
+	server := NewServer(injector)
 	return server, func() {
 	}, nil
+}
+
+// wire.go:
+
+const serviceName = "block-scanner"
+
+// NewInitServersFn creates a new grpc server initializer.
+func NewInitServersFn() grpcx.InitServers {
+	return func(s *grpc.Server) {
+		healthServer := health.NewServer()
+		grpc_health_v1.RegisterHealthServer(s, healthServer)
+		healthServer.SetServingStatus(serviceName, grpc_health_v1.HealthCheckResponse_SERVING)
+		reflection.Register(s)
+	}
+}
+
+// InitApplication is used to initialize the application.
+func InitApplication(config *configx.Configuration) (*configx.Application, error) {
+	app, err := config.GetService(serviceName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service %s: %w", serviceName, err)
+	}
+
+	return app, nil
 }


### PR DESCRIPTION
- Update `NewServer` function in `adapter/block/scan/impl.go` to accept an `injector` parameter
- Add a new file `adapter/block/scan/injector.go` containing `Injector` struct
- Modify `adapter/block/scan/wire.go` to include the `block-scanner` service initialization
- Update `adapter/block/scan/wire_gen.go` to use the `Injector` struct for creating the server