### PR TITLE
refactor: refactor SDK initialization process across packages

### DIFF
--- a/adapter/blockscanner/wire.go
+++ b/adapter/blockscanner/wire.go
@@ -83,7 +83,7 @@ func New(v *viper.Viper) (adapterx.Server, func(), error) {
 		grpcx.NewServer,
 		grpcx.NewClient,
 		NewInitServersFn,
-		otelx.NewSDK,
+		otelx.SetupSDK,
 		eventx.NewEventBus,
 		pgx.NewClient,
 

--- a/adapter/blockscanner/wire_gen.go
+++ b/adapter/blockscanner/wire_gen.go
@@ -38,7 +38,7 @@ func New(v *viper.Viper) (adapterx.Server, func(), error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	sdk, cleanup, err := otelx.NewSDK(application)
+	sdk, cleanup, err := otelx.SetupSDK(application)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/adapter/daemon/impl.go
+++ b/adapter/daemon/impl.go
@@ -8,11 +8,14 @@ import (
 )
 
 type impl struct {
+	injector *Injector
 }
 
 // NewServer is a function to create a new server.
-func NewServer() (adapterx.Server, func(), error) {
-	return &impl{}, func() {}, nil
+func NewServer(injector *Injector) (adapterx.Server, func(), error) {
+	return &impl{
+		injector: injector,
+	}, func() {}, nil
 }
 
 func (i *impl) Start(c context.Context) error {

--- a/adapter/daemon/wire.go
+++ b/adapter/daemon/wire.go
@@ -5,6 +5,8 @@
 package daemon
 
 import (
+	"github.com/blackhorseya/ryze/app/infra/configx"
+	"github.com/blackhorseya/ryze/app/infra/otelx"
 	"github.com/blackhorseya/ryze/pkg/adapterx"
 	"github.com/google/wire"
 	"github.com/spf13/viper"
@@ -12,8 +14,17 @@ import (
 
 const serviceName = "daemon"
 
+// InitApplication is a function to initialize application.
+func InitApplication(config *configx.Configuration) (*configx.Application, error) {
+	return config.GetService(serviceName)
+}
+
 func New(v *viper.Viper) (adapterx.Server, func(), error) {
 	panic(wire.Build(
 		NewServer,
+		wire.Struct(new(Injector), "*"),
+		configx.NewConfiguration,
+		InitApplication,
+		otelx.SetupSDK,
 	))
 }

--- a/adapter/platform/wire.go
+++ b/adapter/platform/wire.go
@@ -47,7 +47,7 @@ func New(v *viper.Viper) (adapterx.Server, func(), error) {
 		initApplication,
 		grpcx.NewServer,
 		NewInitServersFn,
-		otelx.NewSDK,
+		otelx.SetupSDK,
 		eventx.NewEventBus,
 		grpcx.NewClient,
 		pgx.NewClient,

--- a/adapter/platform/wire_gen.go
+++ b/adapter/platform/wire_gen.go
@@ -34,7 +34,7 @@ func New(v *viper.Viper) (adapterx.Server, func(), error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	sdk, cleanup, err := otelx.NewSDK(application)
+	sdk, cleanup, err := otelx.SetupSDK(application)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/app/infra/otelx/otelx.go
+++ b/app/infra/otelx/otelx.go
@@ -31,8 +31,8 @@ type SDK struct {
 	serviceName string
 }
 
-// NewSDK creates a new OpenTelemetry SDK.
-func NewSDK(app *configx.Application) (*SDK, func(), error) {
+// SetupSDK creates a new OpenTelemetry SDK.
+func SetupSDK(app *configx.Application) (*SDK, func(), error) {
 	ctx := contextx.Background()
 
 	instance := &SDK{


### PR DESCRIPTION
- Update the method called from `otelx.NewSDK` to `otelx.SetupSDK` in `adapter/blockscanner/wire.go`
- Update the method called from `otelx.NewSDK` to `otelx.SetupSDK` in `adapter/blockscanner/wire_gen.go`
- Introduce a new field `Injector` in the `impl` struct in `adapter/daemon/impl.go`
- Modify the `NewServer` function signature to accept `Injector` in `adapter/daemon/impl.go`
- Add a new function `InitApplication` in `adapter/daemon/wire.go`
- Introduce a new field `Injector` in the `daemon` package in `adapter/daemon/wire_gen.go`
- Update the method called from `otelx.NewSDK` to `otelx.SetupSDK` in `adapter/platform/wire.go`
- Update the method called from `otelx.NewSDK` to `otelx.SetupSDK` in `adapter/platform/wire_gen.go`
- Update the method name from `NewSDK` to `SetupSDK` in `app/infra/otelx/otelx.go`