### PR TITLE
feat: consolidate service initialization logic in various files

### DIFF
--- a/adapter/daemon/grpc_server.go
+++ b/adapter/daemon/grpc_server.go
@@ -2,6 +2,10 @@ package daemon
 
 import (
 	"github.com/blackhorseya/ryze/app/infra/transports/grpcx"
+	accountB "github.com/blackhorseya/ryze/entity/domain/account/biz"
+	blockB "github.com/blackhorseya/ryze/entity/domain/block/biz"
+	netB "github.com/blackhorseya/ryze/entity/domain/network/biz"
+	txB "github.com/blackhorseya/ryze/entity/domain/transaction/biz"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -9,7 +13,12 @@ import (
 )
 
 // NewInitServersFn is a function to create a new init servers function.
-func NewInitServersFn() grpcx.InitServers {
+func NewInitServersFn(
+	blockServer blockB.BlockServiceServer,
+	networkServer netB.NetworkServiceServer,
+	txServer txB.TransactionServiceServer,
+	accountServer accountB.AccountServiceServer,
+) grpcx.InitServers {
 	return func(s *grpc.Server) {
 		// register health server
 		healthServer := health.NewServer()
@@ -19,6 +28,10 @@ func NewInitServersFn() grpcx.InitServers {
 		// register reflection service on gRPC server.
 		reflection.Register(s)
 
-		// TODO: 2024/9/14|sean|register grpc server
+		// register our services
+		blockB.RegisterBlockServiceServer(s, blockServer)
+		netB.RegisterNetworkServiceServer(s, networkServer)
+		txB.RegisterTransactionServiceServer(s, txServer)
+		accountB.RegisterAccountServiceServer(s, accountServer)
 	}
 }

--- a/adapter/daemon/wire_gen.go
+++ b/adapter/daemon/wire_gen.go
@@ -7,10 +7,19 @@
 package daemon
 
 import (
+	"fmt"
+	"github.com/blackhorseya/ryze/app/domain/account"
+	"github.com/blackhorseya/ryze/app/domain/block"
+	"github.com/blackhorseya/ryze/app/domain/network"
+	"github.com/blackhorseya/ryze/app/domain/transaction"
 	"github.com/blackhorseya/ryze/app/infra/configx"
 	"github.com/blackhorseya/ryze/app/infra/otelx"
+	"github.com/blackhorseya/ryze/app/infra/storage/mongodbx"
+	"github.com/blackhorseya/ryze/app/infra/storage/pgx"
+	"github.com/blackhorseya/ryze/app/infra/tonx"
 	"github.com/blackhorseya/ryze/app/infra/transports/grpcx"
 	"github.com/blackhorseya/ryze/pkg/adapterx"
+	"github.com/blackhorseya/ryze/pkg/eventx"
 	"github.com/spf13/viper"
 )
 
@@ -34,18 +43,54 @@ func New(v *viper.Viper) (adapterx.Server, func(), error) {
 		A:     application,
 		OTelx: sdk,
 	}
-	initServers := NewInitServersFn()
-	server, err := grpcx.NewServer(application, initServers)
+	client, err := InitTonClient(configuration)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
 	}
-	adapterxServer, cleanup2, err := NewServer(injector, server)
+	mongoClient, cleanup2, err := mongodbx.NewClientWithClean(application)
 	if err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+	iBlockRepo, err := mongodbx.NewBlockRepo(mongoClient)
+	if err != nil {
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	eventBus := eventx.NewEventBus()
+	blockServiceServer := block.NewBlockService(client, iBlockRepo, eventBus)
+	networkServiceServer := network.NewNetworkService(client)
+	db, err := pgx.NewClient(application)
+	if err != nil {
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	iTransactionRepo, err := pgx.NewTransactionRepo(db)
+	if err != nil {
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	transactionServiceServer := transaction.NewTransactionService(client, iTransactionRepo)
+	accountServiceServer := account.NewAccountService(client)
+	initServers := NewInitServersFn(blockServiceServer, networkServiceServer, transactionServiceServer, accountServiceServer)
+	server, err := grpcx.NewServer(application, initServers)
+	if err != nil {
+		cleanup2()
+		cleanup()
+		return nil, nil, err
+	}
+	adapterxServer, cleanup3, err := NewServer(injector, server)
+	if err != nil {
+		cleanup2()
 		cleanup()
 		return nil, nil, err
 	}
 	return adapterxServer, func() {
+		cleanup3()
 		cleanup2()
 		cleanup()
 	}, nil
@@ -58,4 +103,19 @@ const serviceName = "daemon"
 // InitApplication is a function to initialize application.
 func InitApplication(config *configx.Configuration) (*configx.Application, error) {
 	return config.GetService(serviceName)
+}
+
+// InitTonClient is used to initialize the ton client.
+func InitTonClient(config *configx.Configuration) (*tonx.Client, error) {
+	settings, ok := config.Networks["ton"]
+	if !ok {
+		return nil, fmt.Errorf("network [ton] not found")
+	}
+
+	n := "mainnet"
+	if settings.Testnet {
+		n = "testnet"
+	}
+
+	return tonx.NewClient(tonx.Options{Network: n})
 }

--- a/app/infra/storage/mongodbx/mongodbx.go
+++ b/app/infra/storage/mongodbx/mongodbx.go
@@ -41,8 +41,23 @@ func NewClientWithDSN(dsn string) (*mongo.Client, error) {
 }
 
 // NewClient returns a new mongo client.
+// Deprecated: use NewClientWithClean instead.
 func NewClient(app *configx.Application) (*mongo.Client, error) {
 	return NewClientWithDSN(app.Storage.Mongodb.DSN)
+}
+
+// NewClientWithClean returns a new mongo client with clean function.
+func NewClientWithClean(app *configx.Application) (*mongo.Client, func(), error) {
+	client, err := NewClientWithDSN(app.Storage.Mongodb.DSN)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return client, func() {
+		ctx := contextx.Background()
+		ctx.Info("disconnecting mongodb client")
+		_ = client.Disconnect(ctx)
+	}, nil
 }
 
 // Container is used to represent a mongodb container.


### PR DESCRIPTION
- Add imports for new entities in `grpc_server.go`
- Add functions for new services in `grpc_server.go`
- Add `InitTonClient` function to initialize the ton client in `wire.go`
- Add infrastructure clients and provider sets in `wire.go`
- Add initialization logic for various services in `wire_gen.go`
- Add logic to disconnect mongodb client in `mongodbx.go`