### PR TITLE
refactor: refactor transaction repository interfaces and methods

### DIFF
--- a/app/infra/storage/pgx/transaction_repo.go
+++ b/app/infra/storage/pgx/transaction_repo.go
@@ -104,16 +104,6 @@ func (i *transactionRepo) List(
 	return items, int(count), nil
 }
 
-func (i *transactionRepo) Update(c context.Context, item *model.Transaction) (err error) {
-	// TODO: 2024/9/13|sean|implement me
-	panic("implement me")
-}
-
-func (i *transactionRepo) Delete(c context.Context, id string) (err error) {
-	// TODO: 2024/9/13|sean|implement me
-	panic("implement me")
-}
-
 func (i *transactionRepo) ListByAccount(
 	c context.Context,
 	accountID string,

--- a/entity/domain/transaction/repo/mock_transaction.go
+++ b/entity/domain/transaction/repo/mock_transaction.go
@@ -54,20 +54,6 @@ func (mr *MockITransactionRepoMockRecorder) Create(c, item any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockITransactionRepo)(nil).Create), c, item)
 }
 
-// Delete mocks base method.
-func (m *MockITransactionRepo) Delete(c context.Context, id string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", c, id)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Delete indicates an expected call of Delete.
-func (mr *MockITransactionRepoMockRecorder) Delete(c, id any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockITransactionRepo)(nil).Delete), c, id)
-}
-
 // GetByID mocks base method.
 func (m *MockITransactionRepo) GetByID(c context.Context, id string) (*model.Transaction, error) {
 	m.ctrl.T.Helper()
@@ -113,18 +99,4 @@ func (m *MockITransactionRepo) ListByAccount(c context.Context, accountID string
 func (mr *MockITransactionRepoMockRecorder) ListByAccount(c, accountID, cond any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByAccount", reflect.TypeOf((*MockITransactionRepo)(nil).ListByAccount), c, accountID, cond)
-}
-
-// Update mocks base method.
-func (m *MockITransactionRepo) Update(c context.Context, item *model.Transaction) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", c, item)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Update indicates an expected call of Update.
-func (mr *MockITransactionRepoMockRecorder) Update(c, item any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockITransactionRepo)(nil).Update), c, item)
 }

--- a/entity/domain/transaction/repo/transaction.go
+++ b/entity/domain/transaction/repo/transaction.go
@@ -19,8 +19,6 @@ type ITransactionRepo interface {
 	Create(c context.Context, item *model.Transaction) (err error)
 	GetByID(c context.Context, id string) (item *model.Transaction, err error)
 	List(c context.Context, cond ListTransactionsCondition) (items []*model.Transaction, total int, err error)
-	Update(c context.Context, item *model.Transaction) (err error)
-	Delete(c context.Context, id string) (err error)
 
 	ListByAccount(
 		c context.Context,


### PR DESCRIPTION
- Remove the Update and Delete methods from the ITransactionRepo interface in the transaction.go file
- Remove the Update and Delete methods from the MockITransactionRepo interface in the mock_transaction.go file
- Update the ListByAccount method in the MockITransactionRepo interface in the mock_transaction.go file
- Update the ListByAccount method in the MockITransactionRepoMockRecorder interface in the mock_transaction.go file
- Remove the Update and Delete methods from the transactionRepo struct in the transaction_repo.go file