### PR TITLE
feat: refactor transaction fetching and listing methods

### DIFF
--- a/app/domain/transaction/transaction_service.go
+++ b/app/domain/transaction/transaction_service.go
@@ -163,8 +163,9 @@ func (i *txService) ProcessBlockTransactionsNonStream(
 
 // fetchTransactionsByBlock is used to fetch transactions by block
 //
-//nolint:gocognit // ignore this
+//nolint:gocognit,unparam // ignore this
 func (i *txService) fetchTransactionsByBlock(c context.Context, block *model.Block) (chan *txM.Transaction, error) {
+	// TODO: 2024/10/5|sean|refactor me
 	txChan := make(chan *txM.Transaction)
 
 	go func() {


### PR DESCRIPTION
- Change method name from `FetchTransactionsByBlock` to `fetchTransactionsByBlock` for consistency
- Add new method `ListTransactions` to handle listing transactions with pagination
- Add new method `ListTransactionsByAccount` for retrieving transactions by account with pagination
- Update `ProcessBlockTransactionsNonStream` method to use the new `fetchTransactionsByBlock` method
- Remove unused methods related to transaction fetching and listing
- Improve error handling and context management in new methods